### PR TITLE
Updated link to Advanced Statistical Computing Course

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Also, the book _[Elements of Statistical Learning](http://statweb.stanford.edu/~
 Here are some other free online courses I've [seen recommended](https://docs.google.com/document/d/1YN6BVdReNAYc8B0fjQ84yzDflqmeEPj7S0Xc-9_26R0/). (Machine Learning, Data Science, and related topics.)
 
 * [Machine Learning](https://www.coursera.org/course/machlearning) by Prof. Pedro Domingos of the University of Washington. Domingos wrote the paper ["A Few Useful Things to Know About Machine Learning"](https://homes.cs.washington.edu/~pedrod/papers/cacm12.pdf) quoted earlier in this guide. (Thanks to [paperwork on HN.](https://news.ycombinator.com/item?id=9563501))
-* [Advanced Statistical Computing (Vanderbilt, BIOS366)](http://stronginference.com/Bios366/lectures.html) -- great option, highly interactive (lots of IPython Notebook material)
+* [Advanced Statistical Computing (Vanderbilt, BIOS8366)](http://stronginference.com/Bios8366/lectures.html) -- great option, highly interactive (lots of IPython Notebook material)
 * [Data Science (Harvard, CS109)](http://cs109.github.io/2014/)
 * [Data Science (General Assembly)](https://github.com/justmarkham/DAT3)
 * Data science courses as IPython Notebooks:


### PR DESCRIPTION
Hi there,

I was going through some of the links and noticed the link to the to the Advanced Statistical Computing as course was broken. The course name has been updated from BIOS366 to BIOS8366 and this reflected in the link that I've made changes too.

I hope this is of some help as it's a great resource.

Mark