### PR TITLE
Add links to browser-based tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ I suggest you get your feet wet to start. You'll boost your confidence.
 
 ## Tools you'll need
 
+### Local installation
+
 - [Python](https://www.python.org/). Python 3 is the best option.
 - [IPython and the Jupyter Notebook](http://ipython.org/). (FKA IPython and IPython Notebook.)
 - Some scientific computing packages:
@@ -24,6 +26,13 @@ I suggest you get your feet wet to start. You'll boost your confidence.
 You can install Python 3 and all of these packages in a few clicks with the [Anaconda Python distribution](https://www.anaconda.com/download/). Anaconda is popular in Data Science and Machine Learning communities.
 
 If you're using Python 2.7, don't worry. You don't have to migrate to Python 3 just for this guide. Also, if you're using pip/virtualenv instead of Anaconda, that's alright too! And re: installing packages, this is a helpful doc: [conda vs. pip vs. virtualenv](https://conda.io/docs/commands.html#conda-vs-pip-vs-virtualenv-commands)
+
+### Browser-based
+
+There is a growing list of free browser-based tools. This is a good option if you don't want to install Python or Jupyter, or if you plan to collaborate with others.
+
+- [Colab](https://colab.research.google.com/) provides free GPUs
+- [Deepnote](https://deepnote.com/) allows for real-time collaboration
 
 ## Let's go!
 


### PR DESCRIPTION
I added links to examples of browser-based notebooks. As someone who struggled with installing Python and Jupyter when I just got started, browser-based was a great way for me to get started without getting into the weeds of setting up my environment properly.